### PR TITLE
Fix predict docstring

### DIFF
--- a/app/api.py
+++ b/app/api.py
@@ -34,8 +34,7 @@ async def predict(
     fare: float = 16.5,
     embarked: str = "S"
 ) -> str:
-    """
-    """
+    """Return the survival prediction based on provided passenger features."""
 
     df = pd.DataFrame(
         {


### PR DESCRIPTION
## Summary
- add description to `predict` in the API

## Testing
- `pytest -q` *(fails: import file mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_686926bb95988323864095a791b1ec31